### PR TITLE
apiVersion for Deployment is no beta in Kubernetes v1.18.2

### DIFF
--- a/k8s/kubernetes-dashboard.yaml
+++ b/k8s/kubernetes-dashboard.yaml
@@ -95,7 +95,7 @@ subjects:
 # ------------------- Dashboard Deployment ------------------- #
 
 kind: Deployment
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   labels:
     k8s-app: kubernetes-dashboard


### PR DESCRIPTION
Right now k8s stable release is v1.18.2, and at this moment kind:Deployment uses apiVersion:apps/v1
Solves #2 